### PR TITLE
Use `--version` to check for yarn installation

### DIFF
--- a/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
+++ b/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
@@ -31,7 +31,8 @@ module Fastlane
 
         UI.message("Checking yarn install and dependencies")
         begin
-          Action.sh(self.yarn, print_command: true, print_command_output: true)
+          command = [self.yarn, "--version"].compact.join(" ")
+          Action.sh(command, print_command: true, print_command_output: true)
         rescue Errno::ENOENT => e
           UI.error("Yarn not installed, please install with Homebrew or npm.")
           raise e


### PR DESCRIPTION
This ensures that `yarn install` isn’t run twice, since yarn’s behavior when calling `yarn` with no args is to run `yarn install`.