### PR TITLE
Fix action params and dependency install

### DIFF
--- a/lib/fastlane/plugin/yarn/actions/yarn_action.rb
+++ b/lib/fastlane/plugin/yarn/actions/yarn_action.rb
@@ -2,8 +2,9 @@ module Fastlane
   module Actions
     class YarnAction < Action
       def self.run(params)
-        task = params[:task]
+        flags = params[:flags]
         command = params[:command]
+        options = params[:options]
         package_path = params[:package_path]
 
         # create a new object from yarn helper
@@ -11,9 +12,15 @@ module Fastlane
 
         # Check if yarn is installed
         yarn.check_install
+        yarn.install_dependencies
 
-        # trigger command
-        yarn.trigger(command: command, task: task)
+        if command.downcase.eql? "install"
+          UI.message("Dependencies installed")
+          return
+        else
+          # trigger command
+          yarn.trigger(command: command, flags: flags, options: options)
+        end
       end
 
       def self.description
@@ -35,9 +42,9 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :task,
-                                       env_name: "YARN_TASK",
-                                       description: "Task you want Yarn to perform as listed in package.json file",
+          FastlaneCore::ConfigItem.new(key: :flags,
+                                       env_name: "YARN_FLAGS",
+                                       description: "Flags you want Yarn to perform as listed in package.json file",
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :command,

--- a/lib/fastlane/plugin/yarn/actions/yarn_action.rb
+++ b/lib/fastlane/plugin/yarn/actions/yarn_action.rb
@@ -12,15 +12,14 @@ module Fastlane
 
         # Check if yarn is installed
         yarn.check_install
-        yarn.install_dependencies
 
-        if command.downcase.eql? "install"
-          UI.message("Dependencies installed")
-          return
-        else
-          # trigger command
-          yarn.trigger(command: command, flags: flags, options: options)
+        if params[:auto_install_dependencies]
+          UI.message("Installign dependecies")
+          yarn.install_dependencies
         end
+
+        # trigger command
+        yarn.trigger(command: command, flags: flags, options: options)
       end
 
       def self.description
@@ -61,7 +60,13 @@ module Fastlane
                                        env_name: "YARN_OPTIONS",
                                        description: "Options to pass to Yarn",
                                        optional: true,
-                                       type: String)
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :auto_install_dependencies,
+                                       env_name: "AUTO_INSTALL_DEPENDENCIES",
+                                       description: "Runs yarn install before executing any yarn command",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false)
 
         ]
       end

--- a/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
+++ b/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
@@ -28,11 +28,9 @@ module Fastlane
 
       def check_install
         check_package
-
-        UI.message("Checking yarn install and dependencies")
         begin
           command = [self.yarn, "--version"].compact.join(" ")
-          Action.sh(command, print_command: true, print_command_output: true)
+          Action.sh(command, print_command: false, print_command_output: false)
         rescue Errno::ENOENT => e
           UI.error("Yarn not installed, please install with Homebrew or npm.")
           raise e
@@ -45,8 +43,6 @@ module Fastlane
       end
 
       def check_package
-        UI.message("Checking for valid package.json")
-
         if self.package_path.nil?
           package_path = 'package.json'
         else

--- a/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
+++ b/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
@@ -4,8 +4,9 @@ module Fastlane
       # class methods that you define here become available in your action
       # as `Helper::YarnHelper.your_method`
 
-      attr_accessor :task
+      attr_accessor :flags
       attr_accessor :commands
+      attr_accessor :options
       attr_accessor :package_path
       attr_accessor :yarn
 
@@ -20,8 +21,8 @@ module Fastlane
       end
 
       # Run a certain action
-      def trigger(command: nil, task: nil, print_command: true, print_command_output: true)
-        command = [self.yarn, command, task].compact.join(" ")
+      def trigger(command: nil, flags: nil, options: nil, print_command: true, print_command_output: true)
+        command = [self.yarn, command, flags, options].compact.join(" ")
         Action.sh(command, print_command: print_command, print_command_output: print_command_output)
       end
 
@@ -30,11 +31,17 @@ module Fastlane
 
         UI.message("Checking yarn install and dependencies")
         begin
-          Action.sh(self.yarn, print_command: true, print_command_output: true)
+          command = [self.yarn, "--version"].compact.join(" ")
+          Action.sh(command, print_command: true, print_command_output: true)
         rescue Errno::ENOENT => e
           UI.error("Yarn not installed, please install with Homebrew or npm.")
           raise e
         end
+      end
+
+      def install_dependencies
+        UI.message("Installing dependencies")
+        trigger(command: "install")
       end
 
       def check_package

--- a/lib/fastlane/plugin/yarn/version.rb
+++ b/lib/fastlane/plugin/yarn/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Yarn
-    VERSION = "0.2.0"
+    VERSION = "1.0"
   end
 end


### PR DESCRIPTION
Breaking changes so bumped major version.

This adds the options param to the yarn command and fixes running yarn install twice when sending `install` as a yarn task.

Also renamed the action options to match the yarn usage. for example
```
  Usage: yarn [command] [flags]

  Options:

    -h, --help                  output usage information
    -V, --version               output the version number
    --verbose                   output verbose messages on internal operations
    --offline                   trigger an error if any required dependencies are not available in local cache
    --prefer-offline            use network only if dependencies are not available in local cache
    --strict-semver
    --json
    --ignore-scripts            don't run lifecycle scripts
    --har                       save HAR output of network traffic
    --ignore-platform           ignore platform checks
    --ignore-engines            ignore engines check
    --ignore-optional           ignore optional dependencies
    --force                     ignore all caches
    --no-bin-links              don't generate bin links when setting up packages
    --flat                      only allow one version of a package
    --prod, --production
    --no-lockfile               don't read or generate a lockfile
    --pure-lockfile             don't generate a lockfile
    --global-folder <path>
    --modules-folder <path>     rather than installing modules into the node_modules folder relative to the cwd, output them here
    --cache-folder <path>       specify a custom folder to store the yarn cache
    --mutex <type>[:specifier]  use a mutex to ensure only one yarn instance is executing
    --no-emoji                  disable emoji in output
    --proxy <host>
    --https-proxy <host>
    --no-progress               disable progress bar

  Commands:

    - access
    - add
    - bin
    - cache
    - check
    - clean
    - config
    - generate-lock-entry
    - global
    - info
    - init
    - install
    - licenses
    - link
    - list
    - login
    - logout
    - outdated
    - owner
    - pack
    - publish
    - remove
    - run
    - tag
    - team
    - unlink
    - upgrade
    - upgrade-interactive
    - version
    - versions
    - why

  Run `yarn help COMMAND` for more information on specific commands.
  Visit https://yarnpkg.com/en/docs/cli/ to learn more about Yarn.
```