### PR TITLE
Correctly format options

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,19 @@
-lane :test do
-  yarn
+lane :install_packages do
+  yarn(
+    command: 'install'
+  )
+end
+
+lane :run_command_with_options do
+  yarn(
+    command: 'install',
+    options: '--cache-folder ~/cache_folder' # Also accepts array of strings
+  )
+end
+
+lane :run_command_with_different_package_path do
+  yarn(
+    command: 'install',
+    package_path: '../package.json'
+  )
 end

--- a/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
+++ b/lib/fastlane/plugin/yarn/helper/yarn_helper.rb
@@ -27,10 +27,19 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, flags: nil, options: nil, print_command: true, print_command_output: true)
         unless options == "" || options == [] || options == nil then
-          option_string = options.respond_to?(:join) ? "-- #{options.join(" ")}" : "-- #{options}"
+          options = format_options(options)
+          option_string = options.respond_to?(:join) ? options.join(" ") : options
         end
         command = [self.yarn, flags, command, option_string].compact.join(" ")
         Action.sh(command, print_command: print_command, print_command_output: print_command_output)
+      end
+
+      def format_options(options)
+        if options.kind_of?(Array)
+          options.map! { |i| i.include?("--") ? i : "--#{i}" }
+        else
+          options.include?("--") ? options : "--#{options}"
+        end
       end
 
       def check_install

--- a/lib/fastlane/plugin/yarn/version.rb
+++ b/lib/fastlane/plugin/yarn/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Yarn
-    VERSION = "1.1"
+    VERSION = "1.2"
   end
 end

--- a/spec/yarn_action_spec.rb
+++ b/spec/yarn_action_spec.rb
@@ -25,7 +25,16 @@ describe Fastlane::Actions::YarnAction do
         yarn(command: 'test', options: '--fail-fast', package_path: 'spec/fixtures/package.json')
       end").runner.execute(:test)
 
-      expect(result).to eq("cd spec/fixtures && yarn test -- --fail-fast")
+      expect(result).to eq("cd spec/fixtures && yarn test --fail-fast")
+    end
+    it 'run some script with some option with missing --' do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+        yarn(command: 'test', options: 'fail-fast', package_path: 'spec/fixtures/package.json')
+      end").runner.execute(:test)
+
+      expect(result).to eq("cd spec/fixtures && yarn test --fail-fast")
     end
     it 'run some script with some option provided as list' do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
@@ -34,10 +43,18 @@ describe Fastlane::Actions::YarnAction do
         yarn(command: 'test', options: ['--fail-fast', 'please'], package_path: 'spec/fixtures/package.json')
       end").runner.execute(:test)
 
-      expect(result).to eq("cd spec/fixtures && yarn test -- --fail-fast please")
+      expect(result).to eq("cd spec/fixtures && yarn test --fail-fast --please")
+    end
+    it 'run some script with some option provided as list, one with param value' do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+        yarn(command: 'test', options: ['--fail-fast please', '--verbose'], package_path: 'spec/fixtures/package.json')
+      end").runner.execute(:test)
+
+      expect(result).to eq("cd spec/fixtures && yarn test --fail-fast please --verbose")
     end
     it 'fail if package_path and project root are both provided' do
-
       expect {
         Fastlane::FastFile.new.parse("lane :boom do
           yarn(command: 'test', package_path: 'spec/fixtures/package.json', project_root:'racine')


### PR DESCRIPTION
Fixes the issue with an extra `--` added to the front of command options.